### PR TITLE
initial CML workflow

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -1,19 +1,27 @@
 name: CML Report
-on: [push, pull_request]
+on: push
 jobs:
   run:
     runs-on: [ubuntu-latest]
     container: docker://dvcorg/cml:0-dvc2-base1
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Generate metrics report
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # generate plots
-          dvc plots show --show-vega prc.json > vega.json
-          vl2svg vega.json prc.svg
+          echo "# CML Report" > report.md
 
-          echo "## Metrics report" > report.md
+          echo "## Plots" >> report.md
+          dvc plots diff bigrams-experiment workspace \
+            --show-vega --targets prc.json > vega.json
+          vl2svg vega.json prc.svg
           cml-publish prc.svg --title "Precision & Recall" --md >> report.md
+
+          echo "## Metrics" >> report.md
+          echo "### bigrams-experiment → workspace"
+          dvc metrics diff bigrams-experiment --show-md >> report.md
+
           cml-send-comment report.md

--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -1,0 +1,19 @@
+name: CML Report
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: [ubuntu-latest]
+    container: docker://dvcorg/cml:0-dvc2-base1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate metrics report
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # generate plots
+          dvc plots show --show-vega prc.json > vega.json
+          vl2svg vega.json prc.svg
+
+          echo "## Metrics report" > report.md
+          cml-publish prc.svg --title "Precision & Recall" --md >> report.md
+          cml-send-comment report.md


### PR DESCRIPTION
Uses:

- [x] latest non-GPU CML docker image (ubuntu20.04, py3.8, dvc2)
- [x] `dvc plots diff`
- [x] `dvc metrics diff`
- [x] `cml-publish`
- [x] `cml-send-comment`
- [x] report is posted twice here because this workflow currently runs on both PRs and pushes. Maybe just run on push?
- [x] moved to https://github.com/iterative/example-repos-dev/pull/37
- [ ] larger dataset branch?

It also runs on each commit which may be annoying (https://github.com/iterative/cml/issues/512).