### PR TITLE
Fix CML workflow

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -18,6 +18,7 @@ jobs:
             PREVIOUS_REF=HEAD~1
           else
             PREVIOUS_REF=main
+            git fetch origin main
           fi
 
           dvc plots diff $PREVIOUS_REF workspace \


### PR DESCRIPTION
Specifying `fetch-depth: 2` in the `uses: actions/checkout@v3` step would exclude the `main` reference otherwise.